### PR TITLE
コードの安全化を図りましょう #1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 install:
-	g++ main.cpp fnc.cpp -o unlambda_editor -lncurses -Wno-return-type
+	g++ main.cpp fnc.cpp -o unlambda_editor -std=c++17 -Wall -Wextra -pedantic-errors -lncurses -Wno-return-type -O2 -march=native

--- a/fnc.cpp
+++ b/fnc.cpp
@@ -36,7 +36,7 @@ void Fnc::show(Fnc *cur){
 	_show(cur);
 	if(cur == this) standend();
 }
-void Com::_show(Fnc *cur){
+void Com::_show(Fnc *cur [[maybe_unused]]){
 	addch(text);
 }
 void App::_show(Fnc *cur){

--- a/fnc.h
+++ b/fnc.h
@@ -13,18 +13,19 @@ public:
 	Fnc *insert_left(), *insert_right();
 	Fnc *com(char), *app(char, char);
 	void show(Fnc *);
+	virtual ~Fnc() {}
 };
 
-class Com : public Fnc{
+class Com final : public Fnc{
 	const char text;
 	void _show(Fnc *);
 	~Com();
 public:
 	Com(Fnc *, Fnc **, char);
-	Fnc *child_left(), *child_right();
+	virtual Fnc *child_left(), *child_right() override final;
 };
 
-class App : public Fnc{
+class App final : public Fnc{
 	Fnc *lft, *rgt;
 	void _show(Fnc *);
 	~App();

--- a/fnc.h
+++ b/fnc.h
@@ -1,3 +1,6 @@
+#ifndef FNC_HPP
+#define FNC_HPP
+
 class Fnc{
 	Fnc *par, **ths;
 	virtual void _show(Fnc *) = 0;
@@ -31,3 +34,5 @@ class App : public Fnc{
 public:
 	Fnc *child_left(), *child_right();
 };
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <curses.h>
 #include "fnc.h"
+#include <array>
 
 enum class Command{
 	none,
@@ -14,25 +15,31 @@ enum class Command{
 	brother_left,
 	brother_right,
 	parent
-} list[256];
+};
 
-int main(int argc, char *argv[]){
+int main([[maybe_unused]] int argc, [[maybe_unused]] char *argv[]){
+
+	constexpr auto list = [] {
+		std::array<Command, 256> list{};
+		list[10] = Command::quit;
+		list['a'] = Command::app;
+		list['s'] = Command::com_s;
+		list['k'] = Command::com_k;
+		list['i'] = Command::com_i;
+		list['l'] = Command::child_left;
+		list['r'] = Command::child_right;
+		list['l' & 037] = Command::brother_left;
+		list['r' & 037] = Command::brother_right;
+		list['p'] = Command::parent;
+		return list;
+	}();
+
 	initscr();
 	Fnc *fnc = new Com(nullptr, &fnc, 'i'), *cur = fnc;
 	noecho();
 	keypad(stdscr, TRUE);
 	curs_set(0);
 
-	list[10] = Command::quit;
-	list['a'] = Command::app;
-	list['s'] = Command::com_s;
-	list['k'] = Command::com_k;
-	list['i'] = Command::com_i;
-	list['l'] = Command::child_left;
-	list['r'] = Command::child_right;
-	list['l' & 037] = Command::brother_left;
-	list['r' & 037] = Command::brother_right;
-	list['p'] = Command::parent;
 
 	for(;;){
 		move(0, 0);


### PR DESCRIPTION
- インクルードガードの追加
多重インクルードを避けるため、ヘッダには必ず書くべき
- コンパイラからは使っていないように見えるが必要そうな変数に[[maybe_unused]]を指定
必要なので警告を黙らせる
- 継承を使用するクラスのコードの安全性の向上
それ以上派生しないような書き方になっているのでclassをfinal指定、overrideする場合はoverride指定子を指定するべき
- ビルトインの配列の代わりにstd::arrayを使用
すいません、気分で書き換えてしまいました
- 警告オプションの追加と-std=c++17の指定
ターゲットがg++8.2以上ならより新しい言語仕様使っておけばいいかなと